### PR TITLE
fix!: remove `isInitialProject` from project settings

### DIFF
--- a/proto/projectSettings/v1.proto
+++ b/proto/projectSettings/v1.proto
@@ -30,5 +30,4 @@ message ProjectSettings_1 {
   optional DefaultPresets defaultPresets = 2;
   optional ConfigMetadata configMetadata = 3;
   optional string name = 4;
-  bool isInitialProject = 5;
 }

--- a/schema/projectSettings/v1.json
+++ b/schema/projectSettings/v1.json
@@ -49,12 +49,8 @@
       },
       "additionalProperties": false,
       "required": ["name", "buildDate", "importDate", "fileVersion"]
-    },
-    "isInitialProject": {
-      "type": "boolean",
-      "description": "this allows for checking if the user has already joined a project or if its on the initial 'default' project"
     }
   },
-  "required": ["schemaName", "isInitialProject"],
+  "required": ["schemaName"],
   "additionalProperties": false
 }

--- a/test/fixtures/good-docs-completed.js
+++ b/test/fixtures/good-docs-completed.js
@@ -97,7 +97,6 @@ export const goodDocsCompleted = [
         buildDate: cachedValues.configMetadata.buildDate,
         importDate: cachedValues.configMetadata.importDate,
       },
-      isInitialProject: true,
       deleted: false,
     },
     expected: {},

--- a/test/fixtures/good-docs-minimal.js
+++ b/test/fixtures/good-docs-minimal.js
@@ -46,7 +46,6 @@ export const goodDocsMinimal = [
       },
       links: [],
       deleted: false,
-      isInitialProject: false,
     },
     expected: {},
   },


### PR DESCRIPTION
[Gregor rightly pointed out that this value is synced][0]. Given that this value is currently unused on the frontend, we should remove it.

[0]: https://github.com/digidem/comapeo-core/issues/751#issuecomment-2337594457
