### PR TITLE
chore: make CoreOwnership core IDs required

### DIFF
--- a/proto/coreOwnership/v1.proto
+++ b/proto/coreOwnership/v1.proto
@@ -13,12 +13,12 @@ message CoreOwnership_1 {
 
   Common_1 common = 1;
 
-  bytes authCoreId = 5;
-  bytes configCoreId = 6;
-  bytes dataCoreId = 7;
-  bytes blobCoreId = 8;
-  bytes blobIndexCoreId = 9;
-  CoreSignatures coreSignatures = 10;
+  bytes authCoreId = 5 [(required) = true];
+  bytes configCoreId = 6 [(required) = true];
+  bytes dataCoreId = 7 [(required) = true];
+  bytes blobCoreId = 8 [(required) = true];
+  bytes blobIndexCoreId = 9 [(required) = true];
+  CoreSignatures coreSignatures = 10 [(required) = true];
   bytes identitySignature = 11;
 
   message CoreSignatures {

--- a/schema/coreOwnership/v1.json
+++ b/schema/coreOwnership/v1.json
@@ -11,23 +11,28 @@
     },
     "authCoreId": {
       "type": "string",
-      "description": "Hex-encoded key of auth store writer core"
+      "description": "Hex-encoded key of auth store writer core",
+      "minLength": 1
     },
     "configCoreId": {
       "type": "string",
-      "description": "Hex-encoded key of config store writer core"
+      "description": "Hex-encoded key of config store writer core",
+      "minLength": 1
     },
     "dataCoreId": {
       "type": "string",
-      "description": "Hex-encoded key of data store writer core"
+      "description": "Hex-encoded key of data store writer core",
+      "minLength": 1
     },
     "blobCoreId": {
       "type": "string",
-      "description": "Hex-encoded key of blob store writer core"
+      "description": "Hex-encoded key of blob store writer core",
+      "minLength": 1
     },
     "blobIndexCoreId": {
       "type": "string",
-      "description": "Hex-encoded key of blobIndex store writer core"
+      "description": "Hex-encoded key of blobIndex store writer core",
+      "minLength": 1
     }
   },
   "required": [

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -12,6 +12,10 @@ export function getOwn<T extends object, K extends keyof T>(
   return Object.hasOwn(obj, key) ? obj[key] : undefined
 }
 
+export function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message)
+}
+
 export class ExhaustivenessError extends Error {
   constructor(value: never) {
     super(`Exhaustiveness check failed. ${value} should be impossible`)

--- a/test/fixtures/bad-docs.js
+++ b/test/fixtures/bad-docs.js
@@ -63,6 +63,25 @@ export const badDocs = [
     },
   },
   {
+    text: 'core ownership with empty core ID',
+    /** @type {import('../../dist/index.js').CoreOwnership} */
+    doc: {
+      docId: cachedValues.docId,
+      versionId: cachedValues.versionId,
+      originalVersionId: cachedValues.versionId,
+      schemaName: 'coreOwnership',
+      createdAt: cachedValues.createdAt,
+      updatedAt: cachedValues.updatedAt,
+      links: [],
+      deleted: false,
+      authCoreId: cachedValues.coreId,
+      configCoreId: '',
+      dataCoreId: cachedValues.coreId,
+      blobCoreId: cachedValues.coreId,
+      blobIndexCoreId: cachedValues.coreId,
+    },
+  },
+  {
     text: 'role doc with empty roleId',
     /** @type {import('../../dist/index.js').Role} */
     doc: {


### PR DESCRIPTION
This change:

- Marks all `CoreOwnership` core IDs `required` in the proto
- Gives each core ID a minimum length in the schema
- Validates this length when decoding
- Adds a test for the above
