### PR TITLE
fix: fix AJV runtime validation code ESM compatibility

### DIFF
--- a/scripts/lib/generate-validations.js
+++ b/scripts/lib/generate-validations.js
@@ -2,6 +2,8 @@
 import Ajv from 'ajv'
 import standaloneCode from 'ajv/dist/standalone/index.js'
 
+const ucs2lengthCode = 'require("ajv/dist/runtime/ucs2length").default'
+
 /**
  * Returns generated code for validation functions
  *
@@ -31,8 +33,7 @@ export function generateValidations(config, jsonSchemas) {
     // AJV has [a bug when generating ESM code][0]: it includes `require` in the
     // output. We should be able to remove this once the bug is fixed.
     // [0]: https://github.com/ajv-validator/ajv/issues/2209
-    "import { createRequire } from 'node:module';",
-    'const require = createRequire(import.meta.url);',
-    standaloneCode(ajv, schemaExports),
+    "import ucs2length from './lib/ucs2length.js';",
+    standaloneCode(ajv, schemaExports).replace(ucs2lengthCode, 'ucs2length'),
   ].join('\n')
 }

--- a/src/lib/ucs2length.ts
+++ b/src/lib/ucs2length.ts
@@ -1,0 +1,16 @@
+export default function ucs2length(str: string): number {
+  const len = str.length
+  let length = 0
+  let pos = 0
+  let value
+  while (pos < len) {
+    length++
+    value = str.charCodeAt(pos++)
+    if (value >= 0xd800 && value <= 0xdbff && pos < len) {
+      // high surrogate, and there is a next character
+      value = str.charCodeAt(pos)
+      if ((value & 0xfc00) === 0xdc00) pos++ // low surrogate
+    }
+  }
+  return length
+}


### PR DESCRIPTION
This is a different approach to the fix in #256 because that was not playing nicely with Rollup bundler.

This PR vendors the `ucs2length` code from the AJV runtime (this code checks a string's length), and modifies the generated validation code to use the vendored version.
