### PR TITLE
chore: update comapeo-geometry to 1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@comapeo/geometry": "^1.0.1",
+        "@comapeo/geometry": "^1.0.2",
         "compact-encoding": "^2.12.0",
         "protobufjs": "^7.2.5",
         "type-fest": "^4.26.0"
@@ -300,10 +300,9 @@
       }
     },
     "node_modules/@comapeo/geometry": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@comapeo/geometry/-/geometry-1.0.1.tgz",
-      "integrity": "sha512-ZH9akj8k/awYUm8GVGyGSs99xNGJotWoo3czCS3Ds3/RgewiSxHbe1JU6PnJ/M2sT6GqbTatAGgNky9g5pK6Vg==",
-      "license": "MIT",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@comapeo/geometry/-/geometry-1.0.2.tgz",
+      "integrity": "sha512-q6zadJA3lr85GZPTZ+lol9F6ERRq2Rt4upON7HhcwPPBiCLN696SY03OJZCE6xkXHxjJY98FF5DxVX3W0IftLQ==",
       "dependencies": {
         "protobufjs": "^7.4.0"
       }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "typescript-eslint": "^8.4.0"
   },
   "dependencies": {
-    "@comapeo/geometry": "^1.0.1",
+    "@comapeo/geometry": "^1.0.2",
     "compact-encoding": "^2.12.0",
     "protobufjs": "^7.2.5",
     "type-fest": "^4.26.0"


### PR DESCRIPTION
comapeo-geometry had a bug where it didn't had a `type` field on its schema. This is used in a check in comapeo-core, so we need that udpate on comapeo-schema