### PR TITLE
chore: don't sync semver tags for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: nearform-actions/optic-release-automation-action@v4
         with:
           commit-message: 'Release {version}'
-          sync-semver-tags: true
+          sync-semver-tags: false
           access: 'public'
           # This prefix is added before the prerelease number, e.g. `v3.0.0-next.0`
           prerelease-prefix: 'next'


### PR DESCRIPTION
This is the equivalent to [this change][0]. To quote that commit:

> The optic release option `sync-semver-tags` creates additional tags (`v{MAJOR}`, `v{MAJOR}.{MINOR}`) which are updated on each release.  This currently does not work because this tag push happens with the permissions of the default github actions token, which does not have rule bypass permissions. It's a "soft fail" (the release still gets made), and the full version tag comes from the release creation, which is done by the optic release app, which is included in our ruleset bypass list.
>
> We don't need these tags, and they are not working, so this [commit] turns this option off.

I plan to YOLO-merge this if CI passes.

[0]: https://github.com/digidem/comapeo-core/commit/d3dc9d852d75ba376257ebc94282ebaaf61cf617