### PR TITLE
feat: omitServerProps helper function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@comapeo/geometry": "^1.0.2",
         "compact-encoding": "^2.12.0",
+        "filter-obj": "^6.1.0",
         "protobufjs": "^7.2.5",
         "type-fest": "^4.26.0"
       },
@@ -2081,6 +2082,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/filter-obj": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-6.1.0.tgz",
+      "integrity": "sha512-xdMtCAODmPloU9qtmPcdBV9Kd27NtMse+4ayThxqIHUES5Z2S6bGpap5PpdmNM56ub7y3i1eyr+vJJIIgWGKmA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/find-up": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   "dependencies": {
     "@comapeo/geometry": "^1.0.2",
     "compact-encoding": "^2.12.0",
+    "filter-obj": "^6.1.0",
     "protobufjs": "^7.2.5",
     "type-fest": "^4.26.0"
   },

--- a/scripts/lib/generate-jsonschema-exports.js
+++ b/scripts/lib/generate-jsonschema-exports.js
@@ -48,6 +48,7 @@ export async function generateJSONSchemaExports(jsonSchemas) {
 
   return `import { type JSONSchema7 } from 'json-schema'
 import { type SchemaNameAll } from './types.js'
+import { type MapeoCommon } from './schema/index.js'
 import { type ReadonlyDeep } from 'type-fest'
 
 declare module 'json-schema' {
@@ -57,6 +58,8 @@ declare module 'json-schema' {
 }
 
 type SchemaRecord = Record<SchemaNameAll, ReadonlyDeep<JSONSchema7>>
+
+export const commonSchema = ${printf(jsonSchemas.values.common)} as const satisfies ReadonlyDeep<JSONSchema7>
 
 export const docSchemas = ${printf(docSchemas)} as const satisfies SchemaRecord
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export {
   getVersionId,
   parseVersionId,
   valueOf,
+  omitServerProps,
   type VersionIdObject,
 } from './lib/utils.js'
 


### PR DESCRIPTION
I needed a more flexible version of `valueOf` for removing server-managed props from a Mapeo Doc. In the front-end we are modifying some props such as replacing refs with actual docs, but we still need to be able to strip server properties when editing.

I decided to create a separate function since this is subtly different from `valueOf`, and the name `valueOf` isn't great anyway.