### PR TITLE
feat: add migration metadata to observation schema

### DIFF
--- a/proto/observation/v1.proto
+++ b/proto/observation/v1.proto
@@ -75,4 +75,16 @@ message Observation_1 {
     bytes docId = 1;
     VersionId_1 versionId = 2;
   }
+
+  message MigrationMetadata {
+    bytes originalDocument = 1;
+    message HypercoreMetadata {
+      optional string rootHashChecksum = 1;
+      optional string signature = 2;
+      optional string coreKey = 3;
+      optional uint32 blockIndex = 4;
+    }
+    optional HypercoreMetadata hypercore = 2;
+  }
+  optional MigrationMetadata migrationMetadata = 11;
 }

--- a/schema/observation/v1.json
+++ b/schema/observation/v1.json
@@ -205,6 +205,40 @@
         }
       },
       "required": ["docId", "versionId"]
+    },
+    "migrationMetadata": {
+      "description": "Metadata about the migration of this observation from Mapeo Legacy",
+      "type": "object",
+      "properties": {
+        "originalDocument": {
+          "description": "Hex-encoded raw observation from Mapeo Legacy",
+          "type": "string"
+        },
+        "hypercore": {
+          "type": "object",
+          "properties": {
+            "rootHashChecksum": {
+              "description": "Checksum of the root hash of the old Hypercore",
+              "type": "string",
+              "minLength": 1
+            },
+            "signature": {
+              "description": "Signature of the old Hypercore",
+              "type": "string",
+              "minLength": 1
+            },
+            "coreKey": {
+              "description": "Core key of the old Hypercore",
+              "type": "string",
+              "minLength": 1
+            },
+            "blockIndex": {
+              "description": "Block index of the document",
+              "type": "number"
+            }
+          }
+        }
+      }
     }
   },
   "required": ["schemaName", "tags", "attachments"],

--- a/src/lib/decode-conversions.ts
+++ b/src/lib/decode-conversions.ts
@@ -107,6 +107,7 @@ export const convertObservation: ConvertFunction<'observation'> = (
   const {
     common,
     metadata,
+    migrationMetadata,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     schemaVersion,
     ...rest
@@ -139,6 +140,14 @@ export const convertObservation: ConvertFunction<'observation'> = (
     tags: convertTags(message.tags),
     metadata: metadata ? removeInvalidPositionMetadata(metadata) : {},
     presetRef,
+    migrationMetadata: migrationMetadata
+      ? {
+          ...migrationMetadata,
+          originalDocument: migrationMetadata.originalDocument
+            ? JSON.stringify(migrationMetadata.originalDocument)
+            : undefined,
+        }
+      : undefined,
   }
   return obs
 }

--- a/src/lib/encode-conversions.ts
+++ b/src/lib/encode-conversions.ts
@@ -100,12 +100,24 @@ export const convertObservation: ConvertFunction<'observation'> = (
     }
   }
 
+  let migrationMetadata
+  if (mapeoDoc.migrationMetadata) {
+    migrationMetadata = {
+      ...mapeoDoc.migrationMetadata,
+      originalDocument: Buffer.from(
+        mapeoDoc.migrationMetadata.originalDocument || '',
+        'hex'
+      ),
+    }
+  }
+
   return {
     common: convertCommon(mapeoDoc),
     ...mapeoDoc,
     attachments,
     tags: convertTags(mapeoDoc.tags),
     presetRef,
+    migrationMetadata,
   }
 }
 


### PR DESCRIPTION
This adds a new field, `migrationMetadata`, which has two sub-fields:
    
- `originalDocument`: the original observation, in case we ever need it
- `hypercore`: metadata about the observation in the old Hypercore

I considered adding this to the `Common` schema, but I don't think it makes sense there because we won't necessarily be migrating all types, like `CoreOwnership`.