### PR TITLE
feat: add project color and description fields to project settings

### DIFF
--- a/proto/projectSettings/v1.proto
+++ b/proto/projectSettings/v1.proto
@@ -30,4 +30,6 @@ message ProjectSettings_1 {
   optional DefaultPresets defaultPresets = 2;
   optional ConfigMetadata configMetadata = 3;
   optional string name = 4;
+  optional string projectDescription = 5;
+  optional string projectColor = 6;
 }

--- a/schema/projectSettings/v1.json
+++ b/schema/projectSettings/v1.json
@@ -13,6 +13,15 @@
       "description": "name of the project",
       "type": "string"
     },
+    "projectDescription": {
+      "description": "description of the project",
+      "type": "string"
+    },
+    "projectColor": {
+      "description": "color associated with a project represented in 24 bit (#rrggbb)",
+      "type": "string",
+      "pattern": "^#[a-fA-F0-9]{6}$"
+    },
     "defaultPresets": {
       "type": "object",
       "properties": {

--- a/src/lib/encode-conversions.ts
+++ b/src/lib/encode-conversions.ts
@@ -26,6 +26,14 @@ export const convertProjectSettings: ConvertFunction<'projectSettings'> = (
   mapeoDoc
 ) => {
   const { defaultPresets } = mapeoDoc
+
+  const colorRegex = RegExp(
+    valueSchemas.projectSettings.properties.projectColor.pattern
+  )
+  if (mapeoDoc.projectColor && !colorRegex.test(mapeoDoc.projectColor)) {
+    throw new Error(`invalid color string ${mapeoDoc.projectColor}`)
+  }
+
   return {
     common: convertCommon(mapeoDoc),
     ...mapeoDoc,

--- a/test/fixtures/bad-docs.js
+++ b/test/fixtures/bad-docs.js
@@ -189,4 +189,20 @@ export const badDocs = [
       sourceId: '',
     },
   },
+  {
+    text: 'projectSettings with invalid project color string',
+    /** @type {import('../../dist/index.js').ProjectSettings} */
+    doc: {
+      docId: cachedValues.docId,
+      versionId: cachedValues.versionId,
+      originalVersionId: cachedValues.versionId,
+      schemaName: 'projectSettings',
+      createdAt: cachedValues.createdAt,
+      updatedAt: cachedValues.updatedAt,
+      links: [],
+      deleted: false,
+      // This is an invalid color value (`g` is out of range)
+      projectColor: '#ff00g1',
+    },
+  },
 ]

--- a/test/fixtures/good-docs-completed.js
+++ b/test/fixtures/good-docs-completed.js
@@ -98,6 +98,8 @@ export const goodDocsCompleted = [
         importDate: cachedValues.configMetadata.importDate,
       },
       deleted: false,
+      projectDescription: 'the funnest project',
+      projectColor: '#E5F0FF',
     },
     expected: {},
   },


### PR DESCRIPTION
Addresses https://github.com/digidem/comapeo-core/issues/1014

- `projectDescription` is an **optional** string
- `projectColor` is an **optional** string, where the string must be hex formatted (e.g. `#000000`). we could make this a required field but I believe that would require backfilling a default value for documents from older schema versions. I feel a bit uneasy about the schema being prescriptive for something like that, which is usually app-specific.