### PR TITLE
chore(ci): add workflow for lockfile checks

### DIFF
--- a/.github/workflows/lockfile.yml
+++ b/.github/workflows/lockfile.yml
@@ -1,0 +1,34 @@
+name: Check Lockfile
+on:
+  pull_request:
+
+jobs:
+  lockfile_version:
+    name: Lockfile version check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out a copy of the repo
+        uses: actions/checkout@v4
+      - name: Check package-lock.json version has not been changed
+        uses: digidem/npm-lockfile-version@c42a24936edf4bdab05f57ff1f07781375a14f5c
+        with:
+          version: 3
+  lockfile_changes:
+    name: Lockfile changes check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out a copy of the repo
+        uses: actions/checkout@v4
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.LOCKFILE_BOT_APP_ID }}
+          private-key: ${{ secrets.LOCKFILE_BOT_PRIVATE_KEY }}
+      - name: NPM Lockfile Changes
+        # The original doesn't support v3 lockfiles so we use a fork that adds support for them
+        # The fork doesn't update comments by an app token, so we use our own fork
+        uses: digidem/npm-lockfile-changes@614dfc33742374cb40bec2878e5b690580d11ede
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          updateComment: true


### PR DESCRIPTION
Slightly adapted from https://github.com/digidem/comapeo-mobile/blob/387ab482ee4e76d5c6f4a68cb47f81863c603945/.github/workflows/lockfile.yml