### PR TITLE
fix: add FNumber to photo exif type

### DIFF
--- a/proto/observation/v1.proto
+++ b/proto/observation/v1.proto
@@ -46,6 +46,7 @@ message Observation_1 {
     optional string Model = 18;
     optional double Orientation = 19;
     optional double ShutterSpeedValue = 20;
+    optional double FNumber = 21;
   }
   message Attachment {
     bytes driveDiscoveryId = 1 [(required) = true];

--- a/schema/observation/v1.json
+++ b/schema/observation/v1.json
@@ -45,6 +45,9 @@
                 "Flash": {
                   "type": "number"
                 },
+                "FNumber": {
+                  "type": "number"
+                },
                 "FocalLength": {
                   "type": "number"
                 },


### PR DESCRIPTION
Related to https://github.com/digidem/comapeo-mobile/issues/1043, where we want to display the `FNumber` field from the EXIF data