### PR TITLE
feat!: add "external" field to attachment definition

### DIFF
--- a/proto/observation/v1.proto
+++ b/proto/observation/v1.proto
@@ -51,7 +51,7 @@ message Observation_1 {
     optional PhotoExif photoExif = 5;
     optional google.protobuf.Timestamp createdAt = 6;
     optional Position position = 7;
-    optional bool external = 8;
+    bool external = 8;
   }
   repeated Attachment attachments = 7;
 

--- a/proto/observation/v1.proto
+++ b/proto/observation/v1.proto
@@ -51,6 +51,7 @@ message Observation_1 {
     optional PhotoExif photoExif = 5;
     optional google.protobuf.Timestamp createdAt = 6;
     optional Position position = 7;
+    optional bool external = 8;
   }
   repeated Attachment attachments = 7;
 

--- a/schema/observation/v1.json
+++ b/schema/observation/v1.json
@@ -84,7 +84,7 @@
               "type": "boolean"
             }
           },
-          "required": ["driveDiscoveryId", "name", "type", "hash"]
+          "required": ["driveDiscoveryId", "name", "type", "hash", "external"]
         },
         {
           "type": "object",
@@ -130,7 +130,7 @@
               "type": "boolean"
             }
           },
-          "required": ["driveDiscoveryId", "name", "type", "hash"]
+          "required": ["driveDiscoveryId", "name", "type", "hash", "external"]
         }
       ]
     },

--- a/schema/observation/v1.json
+++ b/schema/observation/v1.json
@@ -78,6 +78,10 @@
             },
             "position": {
               "$ref": "#/definitions/position"
+            },
+            "external": {
+              "description": "Indicates whether the associated media was created from a source outside of CoMapeo",
+              "type": "boolean"
             }
           },
           "required": ["driveDiscoveryId", "name", "type", "hash"]
@@ -120,6 +124,10 @@
             },
             "position": {
               "$ref": "#/definitions/position"
+            },
+            "external": {
+              "description": "Indicates whether the associated media was created from a source outside of CoMapeo",
+              "type": "boolean"
             }
           },
           "required": ["driveDiscoveryId", "name", "type", "hash"]

--- a/src/lib/decode-conversions.ts
+++ b/src/lib/decode-conversions.ts
@@ -594,6 +594,7 @@ function convertAttachment({
       position: otherProps.position
         ? removeInvalidPosition(otherProps.position)
         : undefined,
+      external: otherProps.external,
     }
   }
   return {
@@ -605,6 +606,7 @@ function convertAttachment({
     position: otherProps.position
       ? removeInvalidPosition(otherProps.position)
       : undefined,
+    external: otherProps.external,
   }
 }
 

--- a/src/lib/encode-conversions.ts
+++ b/src/lib/encode-conversions.ts
@@ -352,6 +352,7 @@ function convertAttachment(
       photoExif: attachment.photoExif,
       createdAt: attachment.createdAt,
       position: attachment.position,
+      external: attachment.external,
     }
   } else
     return {
@@ -361,5 +362,6 @@ function convertAttachment(
       hash: Buffer.from(attachment.hash, 'hex'),
       createdAt: attachment.createdAt,
       position: attachment.position,
+      external: attachment.external,
     }
 }

--- a/test/fixtures/good-docs-completed.js
+++ b/test/fixtures/good-docs-completed.js
@@ -53,6 +53,7 @@ export const goodDocsCompleted = [
             },
             mocked: false,
           },
+          external: true,
         },
         {
           name: 'myFile',
@@ -73,6 +74,7 @@ export const goodDocsCompleted = [
               accuracy: 2.1,
             },
           },
+          external: false,
         },
       ],
       tags: {
@@ -149,6 +151,7 @@ export const goodDocsCompleted = [
               accuracy: 2.1,
             },
           },
+          external: false,
         },
       ],
       tags: {},


### PR DESCRIPTION
Closes #298 

Adds an ~optional~ boolean field to an attachment called `external`, which indicates whether the associated media for an attachment was created outside of CoMapeo e.g. manually uploading an image/video/audio file that was created from another device, application that isn't CoMapeo, etc.

The user-facing intent of this is to determine if the attachment is "validated" by CoMapeo.